### PR TITLE
socks: fix expected length of SOCKS5 reply

### DIFF
--- a/lib/socks.c
+++ b/lib/socks.c
@@ -935,6 +935,13 @@ CURLcode Curl_SOCKS5(const char *proxy_user,
       /* IPv6 */
       len = 4 + 16 + 2;
     }
+    else if(socksreq[3] == 1) {
+      len = 4 + 4 + 2;
+    }
+    else {
+      failf(data, "SOCKS5 reply has wrong address type.");
+      return CURLE_COULDNT_CONNECT;
+    }
 
     /* At this point we already read first 10 bytes */
 #if defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI)


### PR DESCRIPTION
Commit 4a4b63d forgot to set the expected SOCKS5 reply length when the reply ATYP is X'01'. This resulted in erroneously expecting more bytes when the request length is greater than the reply length (e.g., when remotely resolving the hostname).